### PR TITLE
Track dates in YYYY-MM-DD format

### DIFF
--- a/src/components/Calendar/Calendar.jsx
+++ b/src/components/Calendar/Calendar.jsx
@@ -4,10 +4,7 @@ import { AppContext } from "../../App";
 import { range } from "../../services/arrayServices";
 import { createWeekRows, getMonthInfo } from "../../services/calendarServices";
 import { totalAmount } from "../../services/currencyServices";
-import {
-  convertToTimestamp,
-  MAX_DAYS_IN_MONTH
-} from "../../services/dateServices";
+import { makeDateString, MAX_DAYS_IN_MONTH } from "../../services/dateServices";
 import { filterByDate } from "../../services/objectServices";
 import "../../styles/Calendar.scss";
 import { DayModal } from "../DayModal";
@@ -41,7 +38,7 @@ export const Calendar = () => {
     selectedMonth.label
   ];
 
-  let todaysTimestamp,
+  let todaysDate,
     todaysIncomes,
     todaysExpenses,
     todayHasEntries,
@@ -52,9 +49,9 @@ export const Calendar = () => {
 
   // Create an entry for each day of month
   range(1, daysInMonth + 1).forEach(dayNumber => {
-    todaysTimestamp = convertToTimestamp(dayNumber, selectedMonth.label);
-    todaysIncomes = filterByDate(incomes, todaysTimestamp);
-    todaysExpenses = filterByDate(expenses, todaysTimestamp);
+    todaysDate = makeDateString(dayNumber, selectedMonth.label);
+    todaysIncomes = filterByDate(incomes, todaysDate);
+    todaysExpenses = filterByDate(expenses, todaysDate);
     todayHasEntries = !isEmpty(todaysIncomes) || !isEmpty(todaysExpenses);
 
     // Start styling, at the latest, from the first day with entries
@@ -81,7 +78,7 @@ export const Calendar = () => {
       <CalendarDay
         key={dayNumber}
         number={dayNumber}
-        date={todaysTimestamp}
+        date={todaysDate}
         setState={setState}
         hasCash={currentBalance > 0}
         hasEntries={todayHasEntries}

--- a/src/mockData.js
+++ b/src/mockData.js
@@ -14,7 +14,7 @@ export const exampleMonthlyData = {
         name: "Acme Inc. paycheck",
         amount: 185000,
         recurring: true,
-        date: 1570255200000
+        date: "2019-10-05"
         // date: "Saturday, October 5, 2019"
       },
       "2": {
@@ -23,7 +23,7 @@ export const exampleMonthlyData = {
         name: "Acme Inc. paycheck",
         amount: 185000,
         recurring: true,
-        date: 1571896800000
+        date: "2019-10-24"
         //  date: "Thursday, October 24, 2019"
       }
     },
@@ -34,7 +34,7 @@ export const exampleMonthlyData = {
         name: "Apt. Rent",
         amount: 170000,
         recurring: true,
-        date: 1571119200000
+        date: "2019-10-15"
         //  date: "Tuesday, October 15, 2019"
       },
       "3": {
@@ -43,7 +43,7 @@ export const exampleMonthlyData = {
         name: "for car",
         amount: 20000,
         recurring: true,
-        date: 1571119200000
+        date: "2019-10-15"
         //  date: "Tuesday, October 15, 2019"
       },
       "4": {
@@ -52,7 +52,7 @@ export const exampleMonthlyData = {
         name: "Holiday Gifts",
         amount: 25,
         recurring: true,
-        date: 1571119200000
+        date: "2019-10-15"
         //  date: "Tuesday, October 15, 2019"
       }
     }
@@ -72,7 +72,7 @@ export const exampleMonthlyData = {
         name: "Acme Inc. paycheck",
         amount: 110000,
         recurring: true,
-        date: 1573801200000
+        date: "2019-11-15"
         //  date: "Friday, November 15, 2019"
       }
     },
@@ -83,7 +83,7 @@ export const exampleMonthlyData = {
         name: "Apt. Rent",
         amount: 100000,
         recurring: true,
-        date: 1572937200000
+        date: "2019-11-05"
         //  date: "Tuesday, November 5, 2019"
       }
     }

--- a/src/services/dateServices.js
+++ b/src/services/dateServices.js
@@ -29,11 +29,11 @@ export const MAX_DAYS_IN_MONTH = 31;
 
 /**
  * Returns a string for the day
- * @param {Number} timestamp
+ * @param {String} dateString YYYY-MM-DD
  * @returns {String} ex. 'Thursday, October 31'
  */
-export const dayString = timestamp => {
-  let date = new Date(timestamp);
+export const dayString = dateString => {
+  let date = new Date(dateString + "T00:00:00");
   let day = DAY_NAMES[date.getDay()];
   let month = MONTH_NAMES[date.getMonth()];
   let dayNumber = date.getDate();
@@ -42,18 +42,16 @@ export const dayString = timestamp => {
 };
 
 /**
- * Returns the number of milliseconds since the epoch
- * @param {Number} dayOfMonth 31
- * @param {String} monthYear "October 2019"
+ *
+ * @param {Number} day Day of month
+ * @param {String} monthYear ex. "October 2019"
  */
-export const convertToTimestamp = (dayOfMonth, monthYear) => {
+export const makeDateString = (day, monthYear) => {
   let [month, year] = monthYear.split(" ");
-  month = getMonthNumber(month);
-  year = Number.parseInt(year);
+  month = getMonthNumber(month) + 1;
+  const dayString = day < 10 ? `0${day}` : day;
 
-  let date = new Date(year, month, dayOfMonth);
-
-  return date.getTime();
+  return `${year}-${month}-${dayString}`;
 };
 
 /**


### PR DESCRIPTION
Timestamps were not compatible across timezones.

This PR converts to using date strings.

Tested with mockData.js by changing the timezone on my local machine and manually validating that the entries from mockData.js showed up in the Calendar on the expected days.